### PR TITLE
[WIP] Fix handling of files ending in chat_snap.1 and chat_snap.2

### DIFF
--- a/snaprecovery.sh
+++ b/snaprecovery.sh
@@ -59,7 +59,7 @@ COUNT=1
 
 for SNAP in .tmp/*; do
     EXTENSION=$(file --mime-type -b "$SNAP" | sed 's/.*\///g')
-    NEW_FILENAME=$(echo "$SNAP" | sed "s/chat_snap\.0/$EXTENSION/g")
+    NEW_FILENAME=$(echo "$SNAP" | sed "s/chat_snap\.[012]/$EXTENSION/g")
 
     # \r            Move cursor to the start of the current line
     # \e[<NUM>K     Move cursor up N lines   


### PR DESCRIPTION
#### Problem
Some files will be retrieved which end in either `chat_snap.1` or `chat_snap.2`. These files have MIME types `video/mp4` (for `chat_snap.1`) and `image/png` or `image/webp` (for `chat_snap.2`). However, they are not renamed with their correct file extensions.
#### Solution
This PR allows renaming those files to their correct extensions, as currently only files ending in `chat_snap.0` are renamed.