### PR TITLE
Use ffmpeg to merge videos with overlays

### DIFF
--- a/snaprecovery.sh
+++ b/snaprecovery.sh
@@ -75,6 +75,9 @@ for SNAP in .tmp/*.chat_snap.1; do
     OVERLAY="${SNAP%1}2"
     NEW_FILENAME="${SNAP%chat_snap.1}mkv"
 
+    # if <name>.chat_snap.2 doesn't exist, don't attempt to merge anything
+    [ -f $OVERLAY ] || continue
+
     # \r            Move cursor to the start of the current line
     # \e[<NUM>K     Move cursor up N lines   
     printf "\r\e[2K$RUNNING %b" "Recovering [$COUNT/$TOTAL_FILES]: $NEW_FILENAME"

--- a/snaprecovery.sh
+++ b/snaprecovery.sh
@@ -10,9 +10,6 @@ INFO="\033[94;1m[I]\033[0m"
 RUNNING="\033[37;1m[~]\033[0m"
 NOTICE="\033[93;1m[!]\033[0m"
 
-SERIAL="$1"
-SNAPS_DIRECTORY="snaps_$SERIAL"
-
 usage(){
 cat <<EOF
 usage: snaprecovery [SERIAL]
@@ -27,9 +24,13 @@ EOF
 while [ "$1" ] ; do
     case $1 in
         -h|--help) usage ;;
+        -n|--no-merge) NO_MERGE=1 ;;
+        *) SERIAL="$1" ;;
     esac
     shift
 done
+
+SNAPS_DIRECTORY="snaps_$SERIAL"
 
 for DEPENDENCY in curl adb; do
     if ! command -v "$DEPENDENCY" >/dev/null 2>&1; then
@@ -57,39 +58,53 @@ mkdir -p "$SNAPS_DIRECTORY"
 TOTAL_FILES=$(find .tmp | wc -l | xargs)
 COUNT=1
 
-# For files without overlays, rename with the correct extension
-for SNAP in .tmp/*.chat_snap.0; do
-    EXTENSION=$(file --mime-type -b "$SNAP" | sed 's/.*\///g')
-    NEW_FILENAME=$(echo "$SNAP" | sed "s/chat_snap\.0/$EXTENSION/g")
+# If NO_MERGE is set, rename all files without merging
+if [ -n "$NO_MERGE" ]; then
+    for SNAP in .tmp/*.chat_snap.[012]; do
+        EXTENSION=$(file --mime-type -b "$SNAP" | sed 's/.*\///g')
+        NEW_FILENAME=$(echo "$SNAP" | sed "s/chat_snap\.[012]/$EXTENSION/g")
 
-    # \r            Move cursor to the start of the current line
-    # \e[<NUM>K     Move cursor up N lines   
-    printf "\r\e[2K$RUNNING %b" "Recovering [$COUNT/$TOTAL_FILES]: $NEW_FILENAME"
-    mv "$SNAP" "$NEW_FILENAME"
-    COUNT=$((COUNT + 1))
-done
+        # \r            Move cursor to the start of the current line
+        # \e[<NUM>K     Move cursor up N lines   
+        printf "\r\e[2K$RUNNING %b" "Recovering [$COUNT/$TOTAL_FILES]: $NEW_FILENAME"
+        mv "$SNAP" "$NEW_FILENAME"
+        COUNT=$((COUNT + 1))
+    done
+else # If NO_MERGE is not set, rename singletons and merge overlays
+    # For files without overlays, rename with the correct extension
+    for SNAP in .tmp/*.chat_snap.0; do
+        EXTENSION=$(file --mime-type -b "$SNAP" | sed 's/.*\///g')
+        NEW_FILENAME=$(echo "$SNAP" | sed "s/chat_snap\.0/$EXTENSION/g")
 
-# For files with overlays, use ffmpeg to merge the overlay
-for SNAP in .tmp/*.chat_snap.1; do
-    BASE="$SNAP"
-    OVERLAY="${SNAP%1}2"
-    NEW_FILENAME="${SNAP%chat_snap.1}mkv"
+        # \r            Move cursor to the start of the current line
+        # \e[<NUM>K     Move cursor up N lines   
+        printf "\r\e[2K$RUNNING %b" "Recovering [$COUNT/$TOTAL_FILES]: $NEW_FILENAME"
+        mv "$SNAP" "$NEW_FILENAME"
+        COUNT=$((COUNT + 1))
+    done
 
-    # if <name>.chat_snap.2 doesn't exist, don't attempt to merge anything
-    [ -f $OVERLAY ] || continue
+    # For files with overlays, use ffmpeg to merge the overlay
+    for SNAP in .tmp/*.chat_snap.1; do
+        BASE="$SNAP"
+        OVERLAY="${SNAP%1}2"
+        NEW_FILENAME="${SNAP%chat_snap.1}mkv"
 
-    # \r            Move cursor to the start of the current line
-    # \e[<NUM>K     Move cursor up N lines   
-    printf "\r\e[2K$RUNNING %b" "Recovering [$COUNT/$TOTAL_FILES]: $NEW_FILENAME"
-    
-    # merge overlay onto video
-    ffmpeg -loglevel quiet -i $BASE -i $OVERLAY -filter_complex '[1:v][0:v]scale2ref[overlay][base]; [base][overlay]overlay' -c:a copy $NEW_FILENAME
+        # if <name>.chat_snap.2 doesn't exist, don't attempt to merge anything
+        [ -f $OVERLAY ] || continue
 
-    # remove base, overlay, and unused JSON
-    rm -f $BASE $OVERLAY ${SNAP%chat_snap.1}json
+        # \r            Move cursor to the start of the current line
+        # \e[<NUM>K     Move cursor up N lines   
+        printf "\r\e[2K$RUNNING %b" "Recovering [$COUNT/$TOTAL_FILES]: $NEW_FILENAME"
+        
+        # merge overlay onto video
+        ffmpeg -loglevel quiet -i $BASE -i $OVERLAY -filter_complex '[1:v][0:v]scale2ref[overlay][base]; [base][overlay]overlay' -c:a copy $NEW_FILENAME
 
-    COUNT=$((COUNT + 1))
-done
+        # remove base, overlay, and unused JSON
+        rm -f $BASE $OVERLAY ${SNAP%chat_snap.1}json
+
+        COUNT=$((COUNT + 1))
+    done
+fi
 
 printf "\r\e[2K$GOOD %b\n" "Recoverd $TOTAL_FILES snaps"
 printf "$NOTICE %b\n" "The recovered snaps can be found in '$SNAPS_DIRECTORY'"

--- a/snaprecovery.sh
+++ b/snaprecovery.sh
@@ -73,6 +73,7 @@ if [ -z "${MERGE:+x}" ]; then
         mv "$SNAP" "$NEW_FILENAME"
         COUNT=$((COUNT + 1))
     done
+    rm -f .tmp/*.json
 else # If MERGE is set, rename singletons and merge overlays
     # For files without overlays, rename with the correct extension
     for SNAP in .tmp/*.chat_snap.0; do


### PR DESCRIPTION
Videos with text/stickers are actually stored as two separate files, one for the base video and another for an overlay of the text/stickers with a transparent background.

This PR uses [FFmpeg](https://ffmpeg.org) to merge the videos and their overlays into one video, thus resembling what the user would have seen within Snapchat. The base video and the overlay are then deleted, as well as a useless JSON file corresponding with the two, leaving only the merged video.

I've followed the style used in the rest of the script rather than being POSIX-compliant, since it doesn't make sense to have two different styles only to be halfway compliant.