### PR TITLE
SERIAL is auto set if only one device is connected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+snaps_*/

--- a/snaprecovery.sh
+++ b/snaprecovery.sh
@@ -45,6 +45,14 @@ while [ "$1" ] ; do
     shift
 done
 
+# Check if the device is authorized
+DEVICESTATUS="$(adb devices | grep $SERIAL | cut -f2)"
+if [ "$DEVICESTATUS" = 'unauthorized' ]; then
+  printf "%b device '%s' is not authorized.\n" "$BAD" "$SERIAL"
+  printf "%b your computer is not authorized by your phone. check your phone maybe there is a pop up asking for authorization.\n" "$INFO" 
+  exit 1
+fi
+
 SNAPS_DIRECTORY="snaps_$SERIAL"
 
 for DEPENDENCY in adb awk ${MERGE:+ffmpeg stat touch}; do

--- a/snaprecovery.sh
+++ b/snaprecovery.sh
@@ -1,4 +1,4 @@
-!/bin/sh
+#!/bin/sh
 #
 # by Siddharth Dushantha
 #

--- a/snaprecovery.sh
+++ b/snaprecovery.sh
@@ -15,7 +15,7 @@ cat <<EOF
 usage: snaprecovery [-n, --no-merge] [SERIAL]
 
 The serial number of the device can be found by running 'adb devices'.
-it is not necessary if only one device is connected in adb devices.
+It is not necessary if only one device is connected in adb devices.
 
 Options:
     -n, --no-merge    don't merge videos with their respective overlays
@@ -23,10 +23,10 @@ EOF
     exit 1
 }
 
-# int of the number of device connected to adb
+# Number of devices connected to computer through USB
 DEVICESCOUNT="$(adb devices | awk 'NF && NR>1' | wc -l)"
 
-# if only one device is connected, use it's serial. otherwise the user is required to specify a serial.
+# If only one device is connected, use its serial, otherwise the user is required to specify a serial.
 if [ $DEVICESCOUNT -eq 1 ]; then
     SERIAL="$(adb devices | awk 'NF && FNR==2{print $1}')"
 else

--- a/snaprecovery.sh
+++ b/snaprecovery.sh
@@ -49,7 +49,7 @@ done
 DEVICESTATUS="$(adb devices | grep $SERIAL | cut -f2)"
 if [ "$DEVICESTATUS" = 'unauthorized' ]; then
   printf "%b device '%s' is not authorized.\n" "$BAD" "$SERIAL"
-  printf "%b your computer is not authorized by your phone. check your phone maybe there is a pop up asking for authorization.\n" "$INFO" 
+  printf "%b your computer is not authorized by your phone. check your phone maybe there is a pop up asking for authorization.\n" "$NOTICE" 
   exit 1
 fi
 

--- a/snaprecovery.sh
+++ b/snaprecovery.sh
@@ -47,7 +47,7 @@ done
 
 SNAPS_DIRECTORY="snaps_$SERIAL"
 
-for DEPENDENCY in adb ${MERGE:+ffmpeg stat touch}; do
+for DEPENDENCY in adb awk ${MERGE:+ffmpeg stat touch}; do
     if ! command -v "$DEPENDENCY" >/dev/null 2>&1; then
         printf "%b Could not find '%s', is it installed?\n" "$BAD" "$DEPENDENCY"
         exit 1

--- a/snaprecovery.sh
+++ b/snaprecovery.sh
@@ -14,7 +14,8 @@ usage(){
 cat <<EOF
 usage: snaprecovery [-n, --no-merge] [SERIAL]
 
-The serial number of the device can be found by running 'adb devices'
+The serial number of the device can be found by running 'adb devices'.
+it is not necessary if only one device is connected in adb devices.
 
 Options:
     -n, --no-merge    don't merge videos with their respective overlays
@@ -22,7 +23,15 @@ EOF
     exit 1
 }
 
-[ $# -eq 0 ] || [ "$1" = "" ] && usage
+# int of the number of device connected to adb
+DEVICESCOUNT="$(adb devices | awk 'NF && NR>1' | wc -l)"
+
+# if only one device is connected, use it's serial. otherwise the user is required to specify a serial.
+if [ $DEVICESCOUNT -eq 1 ]; then
+    SERIAL="$(adb devices | awk 'NF && FNR==2{print $1}')"
+else
+    [ $# -eq 0 ] || [ "$1" = "" ] && usage
+fi
 
 # Determines whether or not to merge videos with overlays. Must be unset or null/empty to disable.
 MERGE=yes

--- a/snaprecovery.sh
+++ b/snaprecovery.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+!/bin/sh
 #
 # by Siddharth Dushantha
 #
@@ -48,8 +48,8 @@ done
 # Check if the device is authorized
 DEVICESTATUS="$(adb devices | grep $SERIAL | cut -f2)"
 if [ "$DEVICESTATUS" = 'unauthorized' ]; then
-  printf "%b device '%s' is not authorized.\n" "$BAD" "$SERIAL"
-  printf "%b your computer is not authorized by your phone. check your phone maybe there is a pop up asking for authorization.\n" "$NOTICE" 
+  printf "%b Device '%s' is not authorized.\n" "$BAD" "$SERIAL"
+  printf "%b Check for a confirmation dialog on your device.\n" "$NOTICE" 
   exit 1
 fi
 


### PR DESCRIPTION
close #7

I'm surprised Snapchat didn't fix this behavior of keeping snap in cache, and if they do, we can just roll back the app. 
Thanks for the script OP